### PR TITLE
add logging into flask backend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,25 +1,34 @@
 """entry point for flask backend"""
 
 import datetime
+import google.auth
 
 from dotenv import load_dotenv
 from flask import Flask, render_template, g
 
-from db.cloud_sql import get_user_passwords
-from db.firebase import get_firebase_config, store_time, fetch_times
-from middleware.auth import init_auth_middleware
 from api.accounts import accounts_blueprint
 from api.credentials import credentials_blueprint
+from db.cloud_sql import get_user_passwords
+from db.firebase import get_firebase_config, store_time, fetch_times
+import google.cloud.logging as cloud_logging
+from middleware.auth import init_auth_middleware
+from middleware.api_observability import emit_api_observability
+
+_, project = google.auth.default()
 
 load_dotenv()
 app = Flask(__name__)
 
 # register middleware
 init_auth_middleware(app)
+app.after_request(emit_api_observability)
 
 # register API methods
 app.register_blueprint(accounts_blueprint)
 app.register_blueprint(credentials_blueprint)
+
+client = cloud_logging.Client(project=project)
+logger = client.logger("MAIN_APPLICATION")
 
 
 @app.route("/")
@@ -44,6 +53,8 @@ def root():
         password_info=password_info,
     )
 
+
+logger.log_text("!! flask backend started successfully !!", severity="INFO")
 
 if __name__ == "__main__":
     # for local development only

--- a/backend/middleware/api_observability.py
+++ b/backend/middleware/api_observability.py
@@ -1,0 +1,21 @@
+import google.auth
+from flask import request
+import google.cloud.logging as cloud_logging
+
+_, project = google.auth.default()
+client = cloud_logging.Client(project=project)
+logger = client.logger("HTTPS_REQUEST_LOGS")
+
+
+def emit_api_observability(response):
+    log_data = {
+        "endpoint": request.endpoint,
+        "method": request.method,
+        "url": request.url,
+        "status": response.status,
+    }
+
+    severity = "CRITICAL" if response.status_code >= 500 else "INFO"
+    logger.log_struct(log_data, severity=severity)
+
+    return response

--- a/backend/observability.md
+++ b/backend/observability.md
@@ -125,3 +125,12 @@ WHERE log_name = 'projects/password-manager-osu/logs/HTTPS_REQUEST_LOGS'
   AND JSON_EXTRACT_SCALAR(json_payload, '$.endpoint') = 'credentials.view_all_credentials'
 GROUP BY 1, 2
 ```
+
+
+🚨 note - getting things running locally  🚨
+
+If you're getting an error while running the applicaiton locally, try running the command below. GCP needs to know the user which is invoking the applicaiton in order to send logs correctly.
+
+```
+gcloud auth application-default login
+```

--- a/backend/observability.md
+++ b/backend/observability.md
@@ -1,0 +1,127 @@
+# Observability
+
+This markdown file discusses the different ways the application's performance can be monitored. Broadly speaking there are three fundamental types of observability which production applications should leverage:
+
+* **Logs** - Structured/Unstructured text emitted from the application. Basically distributed print statements which are used to help understand how your application is performing.
+* **Metrics** - Numeric based values which are used to get a gauge of how your application is performing. The two fundamental types are counters and gauges. Counters are used to answer questions like "how many requests has this API seen" while gauges are used to answer questions like "how long are these API requests taking".
+* **Traces** - More advanced form of observability which traces the lifecycle of an application process (like an API request) and gives you insight into how long each portion of your code is taking.
+
+### Logs
+In this applicaiton we leverage GCP's native python logger to emit logs. Logs are structured/unstructured text which are emitted from an application. Below are two examples:
+
+```
+# unstructured
+"The database has thrown an error!"
+
+# structured
+{
+    "api": method_x,
+    "params": {"foo": "bar", "baz": "taz"},
+    "errors": nil
+}
+```
+
+Logs are emitted at different severity levels to denote their context. Broadly speaking the different levels are:
+
+* debug - mainly just for debugging
+* info - just informationl
+* warning - semi serious
+* error - pretty serious
+* critical - most serious omg things are melting down in the reactor
+
+The last thing to note is that a log entry on GCP cannot exceed 16k bytes so be careful how much you're printing.
+
+Below is an example of how to set up a logger in the context of this application:
+
+```python
+import google.auth
+import google.cloud.logging as cloud_logging
+
+# get the default GCP project
+_, project = google.auth.default()
+
+# set up a logging client which points to the project in use
+client = cloud_logging.Client(project=project)
+
+# set up a logger with a custom name space
+logger = client.logger("CLOUD_SQL_CLIENT")
+
+
+# emit structured data
+log_data = {
+    "query_title": "query_x",
+    "sql": "select * from table",
+}
+
+logger.log_struct(log_data, severity="INFO")
+
+# emit unstructured data
+logger.log_text("the goths have breached the walls of rome", severity="CRITICAL")
+```
+
+Once you create logs, the next thing you'll want to do is analyze them! The quick way to do so is via the "Logs explorer" on the GCP dashboard. A few notes about this interface:
+* There is a very nice "time selector" which lets you choice what date range to query logs for.
+* For GCP App Engine logs you'll want to select the "GAE Application" resource from the drop down
+* The "Log name" drop down allows you to choose from the different namespaces you've created.
+* The "Severity" toggle allows you to easily filter based on the logs severity.
+* You can save queries so that way you can easily return to them.
+
+Let's look at an example log:
+* Notice the `jsonPayload`, this is structured data being emitted
+* Notice the `logName`, this is the custom namespace
+* Notice the `timestamp`, this will come in handy!
+
+```JSON
+{
+  "insertId": "p9b7ipfib15g8",
+  "jsonPayload": {
+    "status": "200 OK",
+    "method": "GET",
+    "url": "http://localhost:8080/api/v1/accounts/1234/items",
+    "endpoint": "credentials.view_all_credentials"
+  },
+  "resource": {
+    "type": "global",
+    "labels": {
+      "project_id": "password-manager-osu"
+    }
+  },
+  "timestamp": "2024-02-04T22:35:08.449252591Z",
+  "severity": "INFO",
+  "logName": "projects/password-manager-osu/logs/HTTPS_REQUEST_LOGS",
+  "receiveTimestamp": "2024-02-04T22:35:08.449252591Z"
+}
+```
+
+Below are some queries which may be useful
+```
+# filter to a namespace
+(logName = "projects/password-manager-osu/logs/HTTPS_REQUEST_LOGS")
+
+# filter to a severity
+(logName = "projects/password-manager-osu/logs/HTTPS_REQUEST_LOGS" AND severity="INFO")
+
+# filter to a specific endpoint
+(logName = "projects/password-manager-osu/logs/HTTPS_REQUEST_LOGS" AND severity="INFO" AND jsonPayload.endpoint = "credentials.view_all_credentials")
+```
+
+The second way you can analyze logs is through GCP's "Log analytics" tab. This is a really neat feature which allows you to write SQL against your logs to more easily analyze historical trends. For example, below is a query which:
+
+* Filters to all logs
+* Filters to the https request logs namespace
+* Filters to a certain endpoint
+* Groups the timestamps by minute
+* Gets the count of requests by status
+
+In the dashboard you can run this SQL and then use the built in charting options to easily analyze the data - neat!!
+
+``` SQL
+SELECT 
+  TIMESTAMP_TRUNC(timestamp, MINUTE) as timestamp,
+  JSON_EXTRACT_SCALAR(json_payload, '$.status') AS status,
+  COUNT(*) as request_count
+FROM `password-manager-osu.global._Default._AllLogs`
+WHERE log_name = 'projects/password-manager-osu/logs/HTTPS_REQUEST_LOGS'
+  AND JSON_EXTRACT_SCALAR(json_payload, '$.endpoint') = 'credentials.view_all_credentials'
+GROUP BY 1, 2
+```

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,9 +19,13 @@ Flask==3.0.0
 frozenlist==1.4.1
 google-api-core==2.15.0
 google-auth==2.17.3
+google-cloud-appengine-logging==1.4.0
+google-cloud-audit-log==0.2.5
 google-cloud-core==2.4.1
 google-cloud-datastore==2.15.1
+google-cloud-logging==3.9.0
 googleapis-common-protos==1.62.0
+grpc-google-iam-v1==0.13.0
 grpcio==1.60.0
 grpcio-status==1.60.0
 idna==3.6


### PR DESCRIPTION
this PR integrates our backend flask application with the default GCP logger and adds logging for every API request sent. I also typed up a read me explaining how this works so that way if anyone else wants to add logging into another portion of the application it will be easy to do so!

more information can be found at [Setting Up Cloud Logging for Python](https://cloud.google.com/logging/docs/setup/python)